### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 			<section>
 		        <div class="container">
 		            <div class="row">
-		                <div class="col-sm-4 text-center">
+		                <!-- <div class="col-sm-4 text-center">
 		                    <a href="#"><div class="feature">
 		                        <i class="icon fade-3-4 inline-block mb16 ti ti-book"></i>
 		                        <h4>Publications</h4>
@@ -146,8 +146,8 @@
 		                            
 		                        </p>
 								</div></a>
-		                </div>
-		                <div class="col-sm-4 text-center">
+		                </div> -->
+		                <div class="col-sm-6 text-center">
 		                    <a href="https://github.com/tenx-tech"><div class="feature">
 		                        <i class="icon fade-3-4 inline-block mb16 ti ti-github"></i>
 		                        <h4>GitHub</h4>
@@ -156,7 +156,7 @@
 		                        </p>
 		                    </div></a>
 		                </div>
-		                <div class="col-sm-4 text-center">
+		                <div class="col-sm-6 text-center">
 		                    <a href="https://twitter.com/tenxwallet"><div class="feature">
 		                        <i class="icon fade-3-4 inline-block mb16 ti ti-twitter"></i>
 		                        <h4>Twitter</h4>


### PR DESCRIPTION
For now, all the links points to the TenX Twitter account and Github page.

I also removed the publications section as we don't yet have anything what we can put there.