### PR TITLE
Gtag change

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-130677629-1'); 
+  gtag('config', 'UA-130677629-1');
 </script>
 
 


### PR DESCRIPTION
Changed the google analytics tag to UA-130677629-1. This would put coblox.tech in the same analytics account as tenx.tech. Analytics is collected from scratch.

The coblox blog will use the same google analytics ID.

Please give a week or so for the views to catch data.